### PR TITLE
Assess addition of archiving support functions copyTo and ZipGitHubRepo to epiuf

### DIFF
--- a/R/copyTo.R
+++ b/R/copyTo.R
@@ -1,0 +1,92 @@
+#
+# Project Name : epiuf
+# Script Name  : copyTo
+# GitHub repo  : epiuf
+# Summary      : copies files from one location to another, with options to commit, pull and push to github
+# Date created : 4/3/24
+# Author       : JHD
+# Date reviewed:
+# Reviewed by  :
+
+# Description --------------------------------------------------------------
+# 
+# 
+# 
+# 
+# 
+
+
+# Changes Log --------------------------------------------------------------
+# 
+
+# START of SCRIPT  --------------------------------------------------------
+#' copyTo
+#' 
+#' Description
+#' Wrapper function for file.copy which takes list of files specified and copies
+#' to a desired folder. 
+#' For use when making backups of file: if date_stamp is 
+#' TRUE, a text document is created in the specified folder called 
+#' 'date_last_copy.txt' with todays date written inside. 
+#' For use when saving copied files to a local github reposity: options to make a comit
+#' and pull from then push to github after copying the files.
+#' Utility in data management: retrieve refernce documents used by scripts which 
+#' are external to github and create a backup within the github repository.
+#' 
+#' @param files_to_copy List of filepaths for all files to be copied
+#' @param desitation Filepath for where you want to save the copied files
+#' @param date_stamp Logical - do you want to create a date of backup marker in reference backup folder
+#' @param commit Logical - do you want to make a commit of your repository before extraction?
+#' @param commit_msg If commit, what is your message. Default is: commit pre zip (todays date)
+#' @param pull Logical - do you want to make a pull from github before extraction?
+#' @param push Logical - do you want to make a push to github before extraction?
+
+#' @returns
+#' @export
+#' @author STRAP team \email{strap@epiconcept.fr}
+#' @seealso
+#' For more details see the link below to access the vignette:
+#' \href{../doc/epiuf_package.html}{\code{vignette("epiuf_package")}}
+#'
+#' @examples
+#' 
+#' 
+copyTo <- function(files_to_copy,destination,date_stamp=TRUE,commit=FALSE,commit_msg=NULL,pull=FALSE,push=FALSE){
+  # Copy all files to folder
+  results <- file.copy(from = files_to_copy
+                       , to = destination
+                       ,overwrite = TRUE)
+  # Create date of backup marker in reference backup folder
+  if(date_stamp){
+    writeLines(as.character(Sys.Date()), file.path(destination, "date_last_copy.txt"))
+  }
+  # Output message for what saved where
+  if(any(results)){
+    sucessmsg <- c("The following files were saved:",paste0("\n",files_to_copy[results]), "\nto ", destination, "\non ", as.character(Sys.Date()))
+  }else{sucessmsg <- ""}
+  if(any(results==FALSE)){
+    failmsg <- c("The following files failed to save:",paste0("\n",files_to_copy[!results]))
+  }else{failmsg <- ""}
+  message(sucessmsg,"\n",failmsg)
+  # Commit changes
+  if(commit){
+    if(is.null(commit_msg)){
+      commit_msg <- paste0("files saved ", as.character(Sys.Date()))
+    }
+    files_to_stage <- list.files(destination)
+    for (file in files_to_stage) {
+      system(paste0("git add -f ", destination,"/",file))
+    }
+    system(paste0("git commit -m ",shQuote(commit_msg)))
+  }
+  # send to github if specified
+  if(pull){
+    system("git pull")
+  }
+  if(push){
+    system("git push")
+  }
+}
+
+
+# END of SCRIPT  --------------------------------------------------------

--- a/R/whoSendsThis.R
+++ b/R/whoSendsThis.R
@@ -1,0 +1,83 @@
+#
+# Project Name : epiuf
+# Script Name  : whoSendsThis
+# GitHub repo  : epiuf
+# Summary      : Looks for text strings in dictionary column source_name and generic_name
+# Date created : 4/3/24
+# Author       : JHD
+# Date reviewed:
+# Reviewed by  :
+
+# Description --------------------------------------------------------------
+# 
+# 
+# 
+# 
+# 
+
+
+# Changes Log --------------------------------------------------------------
+# 
+
+# START of SCRIPT  --------------------------------------------------------
+
+
+# END of SCRIPT  --------------------------------------------------------
+
+#' whoSendsThis
+#' 
+#' Description
+#' The aim of this function to is to quickly ascertain which dictionaries- in a
+#' specified folder contain your searchterm.
+#' 
+#' This function looks into the specified file location, and then opens each dictionary
+#' in turn as specified by the dictionary_root_filename and filetags. Once opened it
+#' performs a grep search for the searchterm in the source_name and the generic_name
+#' colunms and lists all matching variablenames in a table. 
+#' 
+#' 
+#' @param searchterm The character string which wish to look
+#' @param filetags The list of dictionary filename endings to search through
+#' @param dictionary_location file path to where all the dictionaries that you want to search through are stored
+#' @param dictionary_root_filename root filename for all the dictionaries that wish to search through, which change only by the filetag at the end
+#' @returns data.frame
+#' @export
+#' @author STRAP team \email{strap@epiconcept.fr}
+#' @seealso
+#' For more details see the link below to access the vignette:
+#' \href{../doc/epiuf_package.html}{\code{vignette("epiuf_package")}}
+#'
+#' @examples
+#' 
+whoSendsThis <- function(searchterm
+                         , filetags
+                         , dictionary_location
+                         , dictionary_root_filename){
+  
+  # Make table to hold information
+  whohasit <- data.frame()
+  
+  # for each country
+  for (ft in filetags){
+    # pull in dictionary
+    openDictionary(paste0(dictionary_location,"/",dictionary_root_filename,ft,".xlsx"))
+    ds <- getDictionary()
+    # check source_name
+    checkinsourcename <- grep(searchterm, ds$source_name, ignore.case = T)
+    if(length(checkinsourcename>0)){
+      insourcename <- paste(ds$source_name[checkinsourcename], collapse=", ")
+    }else{insourcename <- ""}
+    
+    # check generic_name
+    checkingenericname <- grep(searchterm, ds$generic_name, ignore.case = T)
+    if(length(checkingenericname>0)){
+      ingenericname <- paste(ds$generic_name[checkingenericname], collapse=", ")
+    }else{ingenericname <- ""}
+    
+    # addd new row to table
+    whohasit <- rbind(whohasit, c(ft, insourcename, ingenericname))
+  }
+  
+  colnames(whohasit) <- c("Site", "Source names", "Generic names")
+  return(whohasit)
+}

--- a/R/zipGithubRepo.R
+++ b/R/zipGithubRepo.R
@@ -1,0 +1,72 @@
+#
+# Project Name : epiuf
+# Script Name  : zipGithubRepo
+# GitHub repo  : epiuf
+# Summary      : saves zipped github repo to specified location, option to pull and push before
+# Date created : 4/3/24
+# Author       : JHD
+# Date reviewed:
+# Reviewed by  :
+
+# Description --------------------------------------------------------------
+# 
+# 
+# 
+# 
+# 
+
+
+# Changes Log --------------------------------------------------------------
+# 
+
+# START of SCRIPT  --------------------------------------------------------
+
+#' zipGithubRepo
+#' 
+#' Description
+#' Make an extraction from your current github repo and saves it to the indicated
+#' folder under the indicated name. Options to make a comit and pull from then 
+#' push to github before extracting the repository. 
+#' 
+#' @param zipfile_destination Where you want to save your zipped repository
+#' @param zipfile_name What you want to call your saved zipped repository
+#' @param commit Logical - do you want to make a commit of your repository before extraction?
+#' @param commit_msg If commit, what is your message. Default is: commit pre zip (todays date)
+#' @param pull Logical - do you want to make a pull from github before extraction?
+#' @param push Logical - do you want to make a push to github before extraction?
+
+#' @returns 
+#' @export
+#' @author STRAP team \email{strap@epiconcept.fr}
+#' @seealso
+#' For more details see the link below to access the vignette:
+#' \href{../doc/epiuf_package.html}{\code{vignette("epiuf_package")}}
+#'
+#' @examples
+#' 
+zipGithubRepo <- function(zipfile_destination,zipfile_name,commit=TRUE,commit_msg=NULL,pull=TRUE, push=TRUE){
+  # Commit changes
+  if(commit){
+    if(is.null(commit_msg)){
+      commit_msg <- paste0("commit pre zip ", as.character(Sys.Date()))
+    }
+    system("git add .")
+    system(paste0("git commit -m ",shQuote(commit_msg)))
+  }
+  # send to github if specified
+  if(pull){
+    system("git pull")
+  }
+  if(push){
+    system("git push")
+  }
+  # save extraction
+  system(paste0("git archive --format=zip --output=",shQuote(paste0(zipfile_destination,"/",zipfile_name,".zip"))," HEAD"), intern=TRUE)
+  
+  # print message
+  message("Copy of ",sub(".*/", "", getwd()), " repository save to:\n"
+          ,zipfile_destination,"/",zipfile_name, ".zip")
+}
+
+
+# END of SCRIPT  --------------------------------------------------------


### PR DESCRIPTION
These are two function which can be used to 
1) copyTo: retrieve any files external to a github repo (eg those which are referenced by the scripts and thus essential to the functioning of the repo) and save them inside the repo, then comit and send to github
2) ZipGitHubRepo: make an extraction of the repo into a zipped folder to be archived. 

copyTo can be used for everyday copying of a list of files into a single location, without using github. 

I have tried to keep them generic, but they may still be too project specific for inclusion into the epiuf package. What do you think? Would these be useful for any other project you work on or know of?